### PR TITLE
修改定位请求文件

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -73,7 +73,7 @@
                 <string>location</string>
             </array>
         </config-file>
-        <config-file target="*/*-Info.plist" parent="NSLocationAlwaysUsageDescription">
+        <config-file target="*/*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
             <string>为了确保您可以正确使用本应用，请选择允许</string>
         </config-file>
         <!--您申请的高德地图ios key更多详情请看http://www.jianshu.com/p/85aceaee3b35-->


### PR DESCRIPTION
合并代码，解决ios8以上可能不弹出授权请求弹框的问题